### PR TITLE
[feature]예약현황 상태 캘린더에 쌓기, 갯수 표시

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6579,6 +6579,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz",
       "integrity": "sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==",
+      "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },

--- a/src/components/BookedBox/index.tsx
+++ b/src/components/BookedBox/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export type Reservation = {
   date: string;
   status: '예약' | '완료' | '승인';
@@ -7,6 +5,14 @@ export type Reservation = {
 
 type BookedBoxProps = {
   reservations: Reservation[];
+  resData: {
+    date: string;
+    reservations: {
+      completed: number;
+      confirmed: number;
+      pending: number;
+    };
+  }[];
 };
 
 const statusStyles = {
@@ -15,14 +21,29 @@ const statusStyles = {
   승인: 'bg-orange-light text-orange',
 };
 
-function BookedBox({ reservations }: BookedBoxProps) {
+function BookedBox({ reservations, resData }: BookedBoxProps) {
+  const getStatusCounts = (date: string) => {
+    const dataForDate = resData.find((data) => data.date === date);
+    if (dataForDate) {
+      return {
+        예약: dataForDate.reservations.pending || 0,
+        완료: dataForDate.reservations.completed || 0,
+        승인: dataForDate.reservations.confirmed || 0,
+      };
+    }
+    return { 예약: 0, 완료: 0, 승인: 0 };
+  };
+
   return (
     <div className='flex flex-col-reverse w-[100%] h-[80%] gap-[0.25rem]'>
-      {reservations.map((reservation) => (
-        <div key={`${reservation.date}-${reservation.status}`} className={`rounded ${statusStyles[reservation.status]} text-center`}>
-          {reservation.status}
-        </div>
-      ))}
+      {reservations.map((reservation) => {
+        const statusCounts = getStatusCounts(reservation.date);
+        return (
+          <div key={`${reservation.date}-${reservation.status}`} className={`rounded ${statusStyles[reservation.status]} text-center`}>
+            {reservation.status} {statusCounts[reservation.status] > 0 ? `${statusCounts[reservation.status]}` : ''}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/pages/reservationDashboard/calendar.tsx
+++ b/src/pages/reservationDashboard/calendar.tsx
@@ -42,6 +42,8 @@ function calendar2({ selectedActivityId }: ActivityDropDownProps) {
   const [currentMonth, setCurrentMonth] = useState(dayjs());
   const year = currentMonth.format('YYYY');
   const month = currentMonth.format('MM');
+  // const [isCalendarClick, setIsCalendarClick] = useState(false);
+  // const [selectedDate, setSeletedDate] = useState<string | null>();
 
   const { data } = useQuery({
     queryKey: ['reservations', selectedActivityId, year, month],
@@ -92,6 +94,11 @@ function calendar2({ selectedActivityId }: ActivityDropDownProps) {
     return reservations;
   };
 
+  // const handleCalendarClick = (day: string) => {
+  //   setIsCalendarClick(!isCalendarClick);
+  //   setSeletedDate(day);
+  // };
+
   return (
     <div className='text-[#000] my-[1.6rem]'>
       <div className='flex flex-row items-center mb-[2.3rem] justify-between'>
@@ -116,15 +123,17 @@ function calendar2({ selectedActivityId }: ActivityDropDownProps) {
               type='button'
               key={day.format('YYYY-MM-DD')}
               className={`flex w-1/7 h-[8.4rem] p-[0.3rem] border-[#e8e8e8] border flex-col ${day.isSame(currentMonth, 'month') ? '' : 'bg-gray-50'} ${day.isSame(dayjs(), 'day') ? 'border-blue border-[0.2rem]' : ''}  hover:border-blue hover:border-[0.3rem]`}
+              // onClick={() => handleCalendarClick(day.format('YYYY-MM-DD'))}
             >
               <div className='text-left w-[100%]'>
                 <span className=''>{day.date()}</span>
               </div>
-              <BookedBox reservations={reservationsForDay} />
+              <BookedBox reservations={reservationsForDay} resData={data} />
             </button>
           );
         })}
       </div>
+      {/* {isCalendarClick && selectedDate && <ReservationInfo data={selectedDate} activityId={selectedActivityId} />} */}
     </div>
   );
 }


### PR DESCRIPTION
## :writing_hand: Description
<!-- 어떤 내용의 PR인지 간단하게 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
예약 현황 페이지에서 '완료', '예약', '승인' 상태에 따른 상태 박스들 캘린더에 쌓이는 부분 완료했습니다.

+ 이제 해당 날짜 클릭 시 모달 띄워 예약 처리(승인, 거절) 하는 기능 추가할 예정입니다.

## :white_check_mark: Checklist
### PR
<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->
- [x] PR 제목 Convention 확인
>`[Feat] OO` 피쳐, `[fix] OO` 버그 수정, `[refactor] OO` 개선
- [x] Base Branch 확인
> `feat/` 피쳐, `develop`, `main`

- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test
- [x] 로컬 작동 확인

### Additional Notes
<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->
- [ ] (없음)
